### PR TITLE
feat: robust LAN device monitor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install deps
+        run: sudo apt-get update && sudo apt-get install -y shellcheck fping arp-scan bats
+      - name: Shellcheck
+        run: shellcheck monitor/watch-devices.sh
+      - name: Bats tests
+        run: bats tests

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+PKG_MANAGER := $(shell if command -v apt-get >/dev/null 2>&1; then echo apt; elif command -v brew >/dev/null 2>&1; then echo brew; fi)
+
+deps:
+	@if command -v fping >/dev/null 2>&1; then echo "fping already installed"; \
+	elif [ "$(PKG_MANAGER)" = "apt" ]; then sudo apt-get update && sudo apt-get install -y fping; \
+	elif [ "$(PKG_MANAGER)" = "brew" ]; then brew install fping; \
+	else echo "please install fping manually"; fi
+	@if command -v arp-scan >/dev/null 2>&1; then echo "arp-scan already installed"; \
+	elif [ "$(PKG_MANAGER)" = "apt" ]; then sudo apt-get update && sudo apt-get install -y arp-scan; \
+	elif [ "$(PKG_MANAGER)" = "brew" ]; then brew install arp-scan; \
+	else echo "please install arp-scan manually"; fi
+	@if command -v bats >/dev/null 2>&1; then echo "bats already installed"; \
+	elif [ "$(PKG_MANAGER)" = "apt" ]; then sudo apt-get update && sudo apt-get install -y bats; \
+	elif [ "$(PKG_MANAGER)" = "brew" ]; then brew install bats-core; \
+	else echo "please install bats manually"; fi
+
+run:
+	./monitor/watch-devices.sh
+
+test:
+	bats tests

--- a/README.md
+++ b/README.md
@@ -1,1 +1,62 @@
-# codex-playground
+# LAN Device Monitor
+
+This repository provides a simple script to monitor devices on your local network.
+
+## Configuration
+
+Edit `monitor/devices.csv` with entries:
+
+```
+name,addr,type
+Pixel6,192.168.1.71,host
+# add more like: Name,IP,host
+```
+Lines starting with `#` and blank lines are ignored.
+
+## Script
+
+Run the watcher:
+
+```bash
+./monitor/watch-devices.sh
+```
+
+Options:
+
+- `--loop` run continuously
+- `--interval N` seconds between loops (default 10)
+- `--timeout N` ping timeout seconds (default 1)
+- `--retries N` probe retries with exponential backoff (default 3)
+- `--json` output JSON lines
+
+Environment variables:
+
+- `CONFIG` path to CSV (default `monitor/devices.csv`)
+- `LOG` log file (default `monitor/watch.log`)
+- `WEBHOOK_URL` optional URL to POST JSON on state change
+
+Log entries are CSV: `timestamp,state,name,addr,latency_ms`.
+
+Exit status is 0 when all devices are UP, otherwise 1.
+
+## Makefile
+
+```bash
+make deps   # install optional tools (fping, arp-scan, bats)
+make test   # run bats tests
+make run    # execute watcher
+```
+
+## Examples
+
+Run once with JSON output:
+
+```bash
+CONFIG=monitor/devices.csv ./monitor/watch-devices.sh --json
+```
+
+Run continuously every 30 seconds:
+
+```bash
+./monitor/watch-devices.sh --loop --interval 30
+```

--- a/monitor/devices.csv
+++ b/monitor/devices.csv
@@ -1,0 +1,5 @@
+name,addr,type
+Pixel6,192.168.1.71,host
+Router,192.168.1.254,host
+TV,192.168.1.85,host
+# add more like: Name,IP,host

--- a/monitor/watch-devices.sh
+++ b/monitor/watch-devices.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+CONFIG="${CONFIG:-monitor/devices.csv}"
+LOG="${LOG:-monitor/watch.log}"
+INTERVAL=10
+TIMEOUT=1
+RETRIES=3
+JSON_OUTPUT=0
+LOOP=0
+STATE_FILE="${STATE_FILE:-monitor/.state}"
+WEBHOOK_URL="${WEBHOOK_URL:-}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --loop) LOOP=1;;
+    --interval) INTERVAL="$2"; shift;;
+    --timeout) TIMEOUT="$2"; shift;;
+    --retries) RETRIES="$2"; shift;;
+    --json) JSON_OUTPUT=1;;
+    --help) echo "usage: $0 [--loop] [--interval N] [--timeout N] [--retries N] [--json]"; exit 0;;
+    *) echo "unknown flag: $1" >&2; exit 2;;
+  esac
+  shift
+done
+
+probe_once(){
+  local addr="$1" out
+  if command -v fping >/dev/null 2>&1; then
+    if out=$(fping -c1 -t $((TIMEOUT*1000)) "$addr" 2>&1); then
+      PROBE_LATENCY=$(echo "$out" | grep -oE 'min/avg/max = [0-9.]+/[0-9.]+/[0-9.]+' | cut -d'/' -f2 || echo 0)
+      return 0
+    else
+      return 1
+    fi
+  elif command -v ping >/dev/null 2>&1; then
+    if [[ "$(uname)" == "Darwin" ]]; then
+      out=$(ping -c1 -W $((TIMEOUT*1000)) "$addr" 2>&1) || return 1
+    else
+      out=$(ping -c1 -W "$TIMEOUT" "$addr" 2>&1) || return 1
+    fi
+    PROBE_LATENCY=$(echo "$out" | awk -F'time=' '/time=/{split($2,a," "); print a[1]; exit}' || echo 0)
+    return 0
+  else
+    echo "No fping or ping available" >&2
+    return 1
+  fi
+}
+
+probe_host(){
+  local name="$1" addr="$2" attempt=0 delay=1 state latency
+  while (( attempt < RETRIES )); do
+    if probe_once "$addr"; then
+      state=UP
+      latency="$PROBE_LATENCY"
+      break
+    else
+      state=DOWN
+      latency=0
+      attempt=$(( attempt + 1 ))
+      (( attempt < RETRIES )) && sleep "$delay" && delay=$(( delay * 2 ))
+    fi
+  done
+  printf '%s,%s,%s,%s,%s\n' "$(date -Is)" "$state" "$name" "$addr" "$latency"
+}
+
+run_once(){
+  mkdir -p "$(dirname "$LOG")"
+  echo "=== start $(date -Is) ===" >>"$LOG"
+  local tmpfile
+  tmpfile=$(mktemp)
+  while IFS=, read -r name addr _type; do
+    [[ -z "${name// }" ]] && continue
+    probe_host "$name" "$addr" >>"$tmpfile" &
+  done < <(tail -n +2 "$CONFIG" | awk 'NF && $0 !~ /^[[:space:]]*#/')
+  wait
+  cat "$tmpfile" >>"$LOG"
+  if [[ "$JSON_OUTPUT" -eq 1 ]]; then
+    while IFS=, read -r ts state name addr latency; do
+      printf '{"timestamp":"%s","state":"%s","name":"%s","addr":"%s","latency_ms":%s}\n' \
+        "$ts" "$state" "$name" "$addr" "$latency"
+    done < "$tmpfile"
+  else
+    cat "$tmpfile"
+  fi
+  declare -A prev
+  [[ -f "$STATE_FILE" ]] && while IFS=, read -r n s; do prev["$n"]="$s"; done < "$STATE_FILE"
+  local exit_status=0
+: >"${STATE_FILE}.tmp"
+  while IFS=, read -r ts state name addr latency; do
+    [[ "$state" == "DOWN" ]] && exit_status=1
+    if [[ -n "$WEBHOOK_URL" ]] && [[ "${prev[$name]:-}" != "$state" ]]; then
+      curl -fsS -H 'Content-Type: application/json' \
+        -d "$(printf '{"timestamp":"%s","state":"%s","name":"%s","addr":"%s","latency_ms":%s}' "$ts" "$state" "$name" "$addr" "$latency")" \
+        "$WEBHOOK_URL" >/dev/null || true
+    fi
+    echo "$name,$state" >>"${STATE_FILE}.tmp"
+  done < "$tmpfile"
+  mv "${STATE_FILE}.tmp" "$STATE_FILE"
+  rm "$tmpfile"
+  return $exit_status
+}
+
+run_once
+status=$?
+if [[ "$LOOP" -eq 1 ]]; then
+  while sleep "$INTERVAL"; do
+    run_once
+    status=$?
+  done
+fi
+exit $status

--- a/tests/watch-devices.bats
+++ b/tests/watch-devices.bats
@@ -1,0 +1,19 @@
+#!/usr/bin/env bats
+
+setup() {
+  mkdir -p tmp
+  cat <<'EOF' > tmp/devices.csv
+name,addr,type
+Localhost,127.0.0.1,host
+EOF
+}
+
+teardown() {
+  rm -rf tmp
+}
+
+@test "localhost is up" {
+  run bash -c "CONFIG=tmp/devices.csv LOG=tmp/watch.log $BATS_TEST_DIRNAME/../monitor/watch-devices.sh --timeout 1 --retries 1"
+  [ "$status" -eq 0 ]
+  grep -q "UP,Localhost,127.0.0.1" tmp/watch.log
+}


### PR DESCRIPTION
## Summary
- add configurable watch-devices script with retries, concurrency, JSON output and webhook support
- provide Makefile and sample devices.csv for running and testing
- add Bats test and CI workflow running shellcheck + tests

## Testing
- `shellcheck monitor/watch-devices.sh`
- `make deps`
- `make test`
- `make run` (fails: `make: *** [Makefile:18: run] Error 1`)


------
https://chatgpt.com/codex/tasks/task_e_6898821e07f883259b2c029d3cf3ff8e